### PR TITLE
add CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agents
+
+Agent configuration and pointers for AI-assisted development in this repository.
+
+## Project Instructions
+
+- [CLAUDE.md](CLAUDE.md) - Project-specific instructions, conventions, and context for Claude Code.
+
+## Agent Definitions
+
+Specialized agents in [`.claude/agents/`](.claude/agents/):
+
+- [playwright-test-generator.md](.claude/agents/playwright-test-generator.md) - Generates Playwright E2E tests
+- [playwright-test-healer.md](.claude/agents/playwright-test-healer.md) - Heals/fixes broken Playwright tests
+- [playwright-test-planner.md](.claude/agents/playwright-test-planner.md) - Plans Playwright test suites
+
+## MCP Server Configuration
+
+- [.mcp.json](.mcp.json) - Configures PatternFly, Playwright, Playwright Test, and Camel MCP servers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# TSD UI Agent
+
+Quarkus-based backend that manages git repositories, tasks/plans, and integrates with Claude Code CLI for AI-driven plan generation and execution.
+
+## Stack
+
+- Java 25, Quarkus 3.32.x, Hibernate ORM Panache, Apache Camel, LangChain4j
+- Build: Maven (`./mvnw`)
+- Database: PostgreSQL
+
+## Commands
+
+- Dev mode: `./mvnw quarkus:dev`
+- Run tests: `./mvnw test`
+- Build: `./mvnw package`
+- Integration tests: `./mvnw verify -DskipITs=false`
+
+## Project Structure
+
+```
+src/main/java/org/acme/
+  resources/          # REST endpoints (JAX-RS)
+  dto/                # Data transfer objects
+  models/jpa/entity/  # JPA entities (PanacheEntity active record)
+  mapper/             # DTO <-> Entity mappers
+  services/           # Business logic (@ApplicationScoped CDI beans)
+  services/ai/        # LangChain4j AI services
+  services/agent/     # Coding agent (CodingAgentService / ClaudeCodeService)
+  services/git/       # Git operations + Camel routes
+  services/sync/      # GitHub/Jira sync + Camel routes
+  validation/         # Custom Bean Validation
+src/main/resources/
+  application.properties
+src/test/java/org/acme/
+specs/                # Playwright E2E test specs
+.github/workflows/    # CI pipelines (build, E2E, image)
+.claude/agents/       # Claude Code agent definitions (Playwright test agents)
+.mcp.json             # MCP server config (PatternFly, Playwright, Camel)
+```
+
+## Code Patterns
+
+- Entities extend `PanacheEntity` (active record pattern)
+- Services are `@ApplicationScoped` CDI beans
+- Long-running operations use `Thread.startVirtualThread`
+- Transactions use `QuarkusTransaction.requiringNew()` for short-lived units
+- Git operations are delegated through Camel routes via `ProducerTemplate`
+- Configuration via MicroProfile Config (`@ConfigProperty`)
+- Worktrees are used for isolated plan execution branches
+- Claude CLI is invoked as a subprocess with `--output-format stream-json`
+
+## Testing
+
+- Unit tests: `@QuarkusTest` with REST Assured
+- Mocking: `quarkus-junit-mockito`
+- Async: Awaitility
+- E2E: Playwright (specs in `specs/`, CI in `.github/workflows/ci-e2e*.yaml`)
+
+## Important Notes
+
+- Do not commit `.env` files (contains secrets)
+- `tsd-agent.git.base-dir` controls where repositories are cloned
+- MCP servers are configured in `.mcp.json`


### PR DESCRIPTION
## Requirement

### Title: Initialize CLAUDE.md and Create Link to AGENTS.md

#### Summary
This requirement outlines the creation of a new Markdown file named `CLAUDE.md` and the addition of a link to another Markdown file, `AGENTS.md`.

#### Objectives
1. Establish a new documentation file, `CLAUDE.md`.
2. Implement a hyperlink within `CLAUDE.md` directing users to the `AGENTS.md` file.

#### Affected Repositories
- Documentation repository (Specify the repository name if known)

#### Acceptance Criteria
1. A new Markdown file named `CLAUDE.md` is created in the designated repository.
2. The `CLAUDE.md` file contains an active hyperlink to the `AGENTS.md` file.
3. Clicking the link in `CLAUDE.md` directs users to the correct section of `AGENTS.md`.

#### Additional Notes
- Ensure that both files are added to the appropriate version control system (e.g., Git) for tracking changes.
- Verify that the hyperlink syntax is correctly implemented, adhering to Markdown standards (e.g., `[Link Text](relative/path/to/file.md)`).