### PR TITLE
the ui log viewer does not render the line correctly

### DIFF
--- a/ui/client/src/app/pages/git-list/components/workspace-status.tsx
+++ b/ui/client/src/app/pages/git-list/components/workspace-status.tsx
@@ -291,7 +291,6 @@ export const ProvisioningOutputPanel: React.FC<{
     <div style={{ marginTop: "var(--pf-t--global--spacer--sm)" }}>
       <LogViewer
         data={data}
-        hasLineNumbers
         height={300}
         isTextWrapped={false}
         scrollToRow={logLines.length}

--- a/ui/client/src/app/pages/task-list/components/execution-output-panel.tsx
+++ b/ui/client/src/app/pages/task-list/components/execution-output-panel.tsx
@@ -66,7 +66,6 @@ export const ExecutionOutputPanel: React.FC<ExecutionOutputPanelProps> = ({
     <div style={{ marginTop: "var(--pf-t--global--spacer--md)" }}>
       <LogViewer
         data={data}
-        hasLineNumbers
         height={400}
         isTextWrapped={false}
         scrollToRow={logLines.length}


### PR DESCRIPTION
Fixes: https://github.com/carlosthe19916/tsd-ui-agent/issues/104

the ui log viewer does not render the line correctly
to avoid conflicts avoid rendering the line numbers in all log viewer components in the ui