### PR TITLE
If there is a PR opened, it should be clearly visible in the task list, without hiding it in popups

### DIFF
--- a/ui/client/src/app/pages/task-list/task-list.tsx
+++ b/ui/client/src/app/pages/task-list/task-list.tsx
@@ -258,22 +258,17 @@ const TaskListContent: React.FC = () => {
                           </FlexItem>
                           {task.plan?.changeRequestUrl && (
                             <FlexItem>
-                              <Label
-                                color="blue"
-                                isCompact
-                                render={({ className, content }) => (
-                                  <a
-                                    className={className}
-                                    href={task.plan!.changeRequestUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    {content}
-                                  </a>
-                                )}
+                              PR:{" "}
+                              <a
+                                href={task.plan.changeRequestUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
                               >
-                                PR
-                              </Label>
+                                #
+                                {task.plan.changeRequestUrl.match(
+                                  /\/(\d+)\/?$/,
+                                )?.[1] ?? "PR"}
+                              </a>
                             </FlexItem>
                           )}
                           {(task.plan.isPlanGenerationInProgress ||


### PR DESCRIPTION
Fixes: https://github.com/carlosthe19916/tsd-ui-agent/issues/99

## Requirement: Clear Visibility of Pull Requests in Task List

### Summary
Ensure that Pull Requests (PRs) are clearly visible and accessible within the task list, eliminating the need for popup windows or additional navigation.

### Objectives
- Enhance user experience by providing direct access to PRs from the task list.
- Reduce navigation complexity and improve workflow efficiency.

### Affected Repositories
- All repositories utilizing the current task management system.

### Acceptance Criteria
1. A PR opened on any repository should automatically appear in the relevant task list.
2. The PR details, such as title, description, and associated files, should be displayed directly within the task list item.
3. Users can access the full PR page by clicking on the task list item without navigating away from the current view (e.g., via a modal or inline expansion).
4. PRs should remain visible in the task list even when they are closed or merged, for reference purposes.
5. The system should support filtering and sorting of tasks based on PR status (open, closed, etc.).

### Additional Notes
- This requirement applies to all users with access to the task management system and relevant repositories.
- Ensure compatibility with various devices and screen sizes to maintain a consistent user experience.
- Consider performance implications when implementing this feature, ensuring that the task list remains responsive even with numerous PRs associated with tasks.