### PR TITLE
The Requirement default value should be both title and description

### DIFF
--- a/src/main/java/org/acme/resources/TaskResource.java
+++ b/src/main/java/org/acme/resources/TaskResource.java
@@ -220,9 +220,9 @@ public class TaskResource {
         }
         PlanEntity plan = planMapper.toEntity(dto);
 
-        // Auto-populate requirement from task description if not provided
+        // Auto-populate requirement from task title and description if not provided
         if (plan.requirement == null || plan.requirement.isBlank()) {
-            plan.requirement = (task.description != null && !task.description.isBlank()) ? task.description : task.title;
+            plan.requirement = buildInitialRequirement(task);
         }
 
         plan.persist();
@@ -257,7 +257,7 @@ public class TaskResource {
         // Create plan if it does not exist
         if (task.plan == null) {
             PlanEntity plan = new PlanEntity();
-            plan.requirement = (task.description != null && !task.description.isBlank()) ? task.description : task.title;
+            plan.requirement = buildInitialRequirement(task);
             plan.createdAt = java.time.Instant.now();
             plan.updatedAt = plan.createdAt;
             plan.persist();
@@ -536,6 +536,14 @@ public class TaskResource {
         return Response.status(Response.Status.ACCEPTED)
                 .entity(planMapper.toDto(task.plan))
                 .build();
+    }
+
+    private static String buildInitialRequirement(TaskEntity task) {
+        boolean hasDescription = task.description != null && !task.description.isBlank();
+        if (hasDescription) {
+            return task.title + "\n\n" + task.description;
+        }
+        return task.title;
     }
 
     @GET

--- a/src/test/java/org/acme/resources/TaskResourceTest.java
+++ b/src/test/java/org/acme/resources/TaskResourceTest.java
@@ -709,7 +709,7 @@ class TaskResourceTest {
                 .when().post("/tasks/{taskId}/plan", taskId)
                 .then()
                 .statusCode(201)
-                .body("requirement", is("Detailed task description"))
+                .body("requirement", is("Task with description\n\nDetailed task description"))
                 .body("isRequirementInProgress", is(false));
 
         // Trigger enrichment via separate endpoint


### PR DESCRIPTION
Fixes: https://github.com/carlosthe19916/tsd-ui-agent/issues/112

Currently the PlanEntity.requirement is filled by default only using the description of the JIRA/GithubIssue but the right thing to do is to populate the requirement with both separated with a new line character. E.g:
{title}

{description}