### PR TITLE
git messages should contain the model that was used for generating the code

### DIFF
--- a/src/main/java/org/acme/services/ChangeRequestService.java
+++ b/src/main/java/org/acme/services/ChangeRequestService.java
@@ -13,6 +13,7 @@ import org.acme.services.sync.jira.JiraSyncClient;
 import org.acme.services.changerequest.ChangeRequestParams;
 import org.acme.services.changerequest.ChangeRequestProvider;
 import org.acme.services.changerequest.ChangeRequestResult;
+import org.acme.services.codeagent.CodingAgentService;
 import org.acme.services.git.GitManager;
 import org.acme.models.jpa.entity.ExecutionMode;
 import org.acme.services.workspace.Workspace;
@@ -23,6 +24,7 @@ import org.acme.services.workspace.WorkspaceManagerResolver;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.Map;
 
 @ApplicationScoped
 public class ChangeRequestService {
@@ -37,6 +39,9 @@ public class ChangeRequestService {
 
     @Inject
     Instance<ChangeRequestProvider> providers;
+
+    @Inject
+    CodingAgentService codingAgentService;
 
     @Inject
     JiraSyncClient jiraSyncClient;
@@ -96,7 +101,8 @@ public class ChangeRequestService {
 
             try {
                 workspaceGit.addAll(workspace);
-                workspaceGit.commit(workspace, context.taskTitle());
+                workspaceGit.commit(workspace, context.taskTitle(),
+                        Map.of("Assisted-by", codingAgentService.agentLabel()));
             } catch (WorkspaceException e) {
                 if (e.getMessage() != null && e.getMessage().contains("nothing to commit")) {
                     LOG.infof("Task %d: No changes to commit, proceeding with push: %s", taskId, e.getMessage());

--- a/src/main/java/org/acme/services/codeagent/ClaudeCodeService.java
+++ b/src/main/java/org/acme/services/codeagent/ClaudeCodeService.java
@@ -31,6 +31,11 @@ public class ClaudeCodeService implements CodingAgentService {
     String model;
 
     @Override
+    public String agentLabel() {
+        return "Claude Code (" + model + ")";
+    }
+
+    @Override
     public String generatePlan(Workspace workspace, String requirement, Long taskId) {
         String prompt = PLAN_GENERATION_PROMPT.formatted(requirement);
 

--- a/src/main/java/org/acme/services/codeagent/CodingAgentService.java
+++ b/src/main/java/org/acme/services/codeagent/CodingAgentService.java
@@ -14,6 +14,13 @@ public interface CodingAgentService {
             step-by-step implementation instructions, and testing approach.
             """;
 
+    /**
+     * Returns a label identifying this coding agent and its model,
+     * suitable for use in git commit trailers.
+     * Example: "Claude Code (opus)" or "OpenCode (anthropic/claude-opus-4-6)"
+     */
+    String agentLabel();
+
     String generatePlan(Workspace workspace, String requirement, Long taskId);
 
     void executePlan(Workspace workspace, String planText, Long taskId);

--- a/src/main/java/org/acme/services/codeagent/OpenCodeService.java
+++ b/src/main/java/org/acme/services/codeagent/OpenCodeService.java
@@ -32,6 +32,11 @@ public class OpenCodeService implements CodingAgentService {
     String model;
 
     @Override
+    public String agentLabel() {
+        return "OpenCode (" + model + ")";
+    }
+
+    @Override
     public String generatePlan(Workspace workspace, String requirement, Long taskId) {
         String prompt = PLAN_GENERATION_PROMPT.formatted(requirement);
         String worktreeAlias = Path.of(workspace.workingDirectory()).getFileName().toString();

--- a/src/main/java/org/acme/services/workspace/WorkspaceGitOperations.java
+++ b/src/main/java/org/acme/services/workspace/WorkspaceGitOperations.java
@@ -3,6 +3,8 @@ package org.acme.services.workspace;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.util.Map;
+
 @ApplicationScoped
 public class WorkspaceGitOperations {
 
@@ -18,6 +20,19 @@ public class WorkspaceGitOperations {
 
     public void commit(Workspace workspace, String message) {
         workspace.exec("git", "-c", "user.name=" + gitUserName, "-c", "user.email=" + gitUserEmail, "-c", "commit.gpgsign=false", "commit", "-m", message);
+    }
+
+    public void commit(Workspace workspace, String message, Map<String, String> trailers) {
+        String fullMessage = message;
+        if (trailers != null && !trailers.isEmpty()) {
+            StringBuilder sb = new StringBuilder(message);
+            sb.append("\n\n");
+            for (Map.Entry<String, String> entry : trailers.entrySet()) {
+                sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+            }
+            fullMessage = sb.toString().stripTrailing();
+        }
+        workspace.exec("git", "-c", "user.name=" + gitUserName, "-c", "user.email=" + gitUserEmail, "-c", "commit.gpgsign=false", "commit", "-m", fullMessage);
     }
 
     public void push(Workspace workspace, String remoteName, String branchName) {

--- a/src/test/java/org/acme/services/workspace/WorkspaceGitOperationsTest.java
+++ b/src/test/java/org/acme/services/workspace/WorkspaceGitOperationsTest.java
@@ -1,0 +1,118 @@
+package org.acme.services.workspace;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WorkspaceGitOperationsTest {
+
+    private WorkspaceGitOperations workspaceGit;
+    private Workspace workspace;
+
+    @BeforeEach
+    void setup() {
+        workspaceGit = new WorkspaceGitOperations();
+        workspaceGit.gitUserName = "Test User";
+        workspaceGit.gitUserEmail = "test@example.com";
+        workspace = mock(Workspace.class);
+        when(workspace.exec(any(String[].class))).thenReturn("");
+    }
+
+    @Test
+    void commitWithTrailersAppendsTrailerToMessage() {
+        workspaceGit.commit(workspace, "Fix login bug", Map.of("Assisted-by", "Claude Code (opus)"));
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertTrue(commitMessage.startsWith("Fix login bug"), "Message should start with the original text");
+        assertTrue(commitMessage.contains("\n\n"), "Message should have a blank line before trailers");
+        assertTrue(commitMessage.contains("Assisted-by: Claude Code (opus)"),
+                "Message should contain the Assisted-by trailer");
+    }
+
+    @Test
+    void commitWithMultipleTrailersAppendsAll() {
+        Map<String, String> trailers = new LinkedHashMap<>();
+        trailers.put("Assisted-by", "Claude Code (opus)");
+        trailers.put("Task-ID", "42");
+
+        workspaceGit.commit(workspace, "Refactor auth", trailers);
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertTrue(commitMessage.contains("Assisted-by: Claude Code (opus)"));
+        assertTrue(commitMessage.contains("Task-ID: 42"));
+    }
+
+    @Test
+    void commitWithNullTrailersUsesPlainMessage() {
+        workspaceGit.commit(workspace, "Plain commit", (Map<String, String>) null);
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertEquals("Plain commit", commitMessage);
+    }
+
+    @Test
+    void commitWithEmptyTrailersUsesPlainMessage() {
+        workspaceGit.commit(workspace, "Plain commit", Collections.emptyMap());
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertEquals("Plain commit", commitMessage);
+    }
+
+    @Test
+    void commitWithTrailersHasNoTrailingWhitespace() {
+        workspaceGit.commit(workspace, "Fix bug", Map.of("Assisted-by", "OpenCode (anthropic/claude-opus-4-6)"));
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertEquals(commitMessage, commitMessage.stripTrailing(),
+                "Commit message should not have trailing whitespace");
+    }
+
+    @Test
+    void commitWithoutTrailersMethodUnchanged() {
+        workspaceGit.commit(workspace, "Simple commit");
+
+        ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+        verify(workspace).exec(captor.capture());
+
+        String[] args = captor.getValue();
+        String commitMessage = args[args.length - 1];
+
+        assertEquals("Simple commit", commitMessage);
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/carlosthe19916/tsd-ui-agent/issues/122

git messages should contain the model that was used for generating the code

e.g. Assisted-by: <name of code assistant>